### PR TITLE
Show filemode diffs separately

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Force ignore files"
     required: false
     default: ""
+  strict-perms:
+    description: "Strict file permissions. If set to false, filemode-only changes will be ignored on the manifest."
+    required: false
+    default: "true"
 outputs:
   manifest:
     description: "Manifest of files changed"
@@ -52,4 +56,5 @@ runs:
         FROM_DIR: ${{ inputs.from }}
         DEFER_PUSH: ${{ inputs.defer-push }}
         FORCE_IGNORE: ${{ inputs.force-ignore }}
+        STRICT_PERMS: ${{ inputs.strict-perms }}
       run: "${{ github.action_path }}/main.sh"

--- a/main.sh
+++ b/main.sh
@@ -134,7 +134,15 @@ if [ -n "$(git status --porcelain)" ]; then
 		# this will be useful to specifically ignore filemode changes in the manifest if needed
 		# see https://git-scm.com/docs/git-diff-tree#Documentation/git-diff-tree.txt---diff-filterACDMRTUXB82308203
 		# the awk command end up simulating the --name-status output
-		git diff-tree HEAD --no-commit-id --no-renames -r | awk '{ if( $3 == $4 ) print "H\t" $6; else print $5 "\t" $6; }'
+		git diff-tree HEAD --no-commit-id --no-renames -r | {
+			if [ "$STRICT_PERMS" == "false" ]; then
+				# if no strict perms, exclude files that only had filemode changes
+				awk '{ if( $3 != $4 ) print $5 "\t" $6; }'
+			else
+				# otherwise, include them
+				awk '{ if( $3 == $4 ) print "H\t" $6; else print $5 "\t" $6; }'
+			fi
+		}
 	} > "$MANIFEST_RAW_PATH"
 
 	{

--- a/main.sh
+++ b/main.sh
@@ -129,12 +129,13 @@ if [ -n "$(git status --porcelain)" ]; then
 	echo "::endgroup::"
 
 	{
-		git diff-tree HEAD --name-status --no-commit-id --no-renames -r | sed -E "s/^[AM]\t/+ /" | sed -E "s/^[D]\t/- /"
-	} > "$MANIFEST_PATH"
-
-	{
 		git diff-tree HEAD --name-status --no-commit-id --no-renames -r
 	} > "$MANIFEST_RAW_PATH"
+
+	{
+		sed -E "s/^[AM]\t/+ /" "$MANIFEST_RAW_PATH" | sed -E "s/^[D]\t/- /"
+	} > "$MANIFEST_PATH"
+
 fi
 
 {


### PR DESCRIPTION
At least in the raw manifest, I'm outputing file mode only changes as separate operation type.

Git Diff consider the file modified, so if that situation happen (I can explain the git jargon if needed) i put a different operation type, so that it can be filtered later.

As set up currently, all the actions should still be compatible, as only the raw output is changed, the regular "simplified" manifest is not changed in this PR, as the new "H" type of operation (couldn't find another letter) is converted to an addition, same as the old Modified operation would've triggered.